### PR TITLE
Add `/show=N` parameter to allow override of `SW_SHOWNORMAL` in application launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,16 @@ This version of the application will keep trying to exit Windows for ~10 seconds
 * **ShellExecute error codes are now displayed**  
 If ShellExecute fails to run the application, then a message box is displayed along with the error code. A list of error codes are [here](#error-codes).
 
+* **Application startup behavior can be changed**  
+The default application startup `SW_SHOWNORMAL` can be overridden to a different value by passing a `/show=[number]` parameter to `RUNEXIT.EXE`, before the application path. This allows starting the application minimized, maximized, or in the "background" (not activated). A list of valid values are [here](#valid-ncmdshow-values).
+
 # Usage
 
 Download `RUNEXIT.EXE` from the releases page and copy it to your system; these examples will assume that you save it to `C:\RUNEXIT\RUNEXIT.EXE` and that `win` is in your `PATH`.
 
 ## Basic Usage
 
-`win C:\runexit\runexit.exe [path to application] [optional application parameters]`
+`win C:\runexit\runexit.exe [optional runexit parameters] [path to application] [optional application parameters]`
 
 ## Example 1
 Run application `C:\MPS\GPM\GPM.EXE` with no additional parameters.
@@ -48,6 +51,11 @@ Run application `C:\GAMES\MYGAME\GAME.EXE` with parameter `/cheatmode`
 `win C:\runexit\runexit.exe c:\games\mygame\game.exe /cheatmode`
 
 ## Example 3
+Run application `C:\WEP\JEZZBALL.EXE` in a maximized window.
+
+`win C:\runexit\runexit.exe /show=3 c:\wep\jezzball.exe`
+
+## Example 4
 DOSBox AUTOEXEC to run application `C:\MPS\GPM\GPM.EXE` with no additional parameters.  
 On running DOSBox this would load Windows and run the application. Once the application is closed Windows will then exit, and DOSBox will close.
 
@@ -72,18 +80,36 @@ Build from the command line `C:\delphi\bin\dcc.exe c:\runexit\runexit.dpr`
 
 ## Windows API ShellExecute
 
-`ShellExecute (0, nil, @fileName [1], @params [1], @pathName [1], SW_SHOWNORMAL);`
+`ShellExecute (0, nil, @fileName [1], @params [1], @pathName [1], nCmdShow);`
 
-| Parameter     | Description                                                                 |
-|---------------|-----------------------------------------------------------------------------|
-| `0`             | Handle to the parent window. `0` for no parent                              |
-| `nil`           | The operation to perform<br/>A `null` value will use the default of `open`. |
-| `fileName`      | Application name eg. `GPM.EXE`                                              |
-| `params`        | Application parameters eg. `/cheatmode`                                     |
-| `pathName`      | Application path eg. `C:\MPS\GPM`                                           |
-| `SW_SHOWNORMAL` | State the application window is set to to                               |
+| Parameter  | Description                                                                 |
+|------------|-----------------------------------------------------------------------------|
+| `0`        | Handle to the parent window. `0` for no parent                              |
+| `nil`      | The operation to perform<br/>A `null` value will use the default of `open`. |
+| `fileName` | Application name eg. `GPM.EXE`                                              |
+| `params`   | Application parameters eg. `/cheatmode`                                     |
+| `pathName` | Application path eg. `C:\MPS\GPM`                                           |
+| `nCmdShow` | State the application window is set to on launch                            |
 
-### Error Codes
+## Valid `nCmdShow` values
+| Value | Name                                 | Meaning                                                                                                                                                                                                                               |
+|:-----:|--------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 0     | `SW_HIDE`                            | Hides the window and activates another window.                                                                                                                                                                                        |
+| 1     | `SW_SHOWNORMAL`<br/>`SW_NORMAL`      | Activates and displays a window. If the window is minimized, maximized, or arranged, the system restores it to its original size and position. An application should specify this flag when displaying the window for the first time. |
+| 2     | `SW_SHOWMINIMIZED`                   | Activates the window and displays it as a minimized window.                                                                                                                                                                           |
+| 3     | `SW_SHOWMAXIMIZED`<br/>`SW_MAXIMIZE` | Activates the window and displays it as a maximized window.                                                                                                                                                                           |
+| 4     | `SW_SHOWNOACTIVATE`                  | Displays a window in its most recent size and position. This value is similar to `SW_SHOWNORMAL`, except that the window is not activated.                                                                                            |
+| 5     | `SW_SHOW`                            | Activates the window and displays it in its current size and position.                                                                                                                                                                |
+| 6     | `SW_MINIMIZE`                        | Minimizes the specified window and activates the next top-level window in the Z order.                                                                                                                                                |
+| 7     | `SW_SHOWMINNOACTIVE`                 | Displays the window as a minimized window. This value is similar to `SW_SHOWMINIMIZED`, except the window is not activated.                                                                                                           |
+| 8     | `SW_SHOWNA`                          | Displays the window in its current size and position. This value is similar to `SW_SHOW`, except that the window is not activated.                                                                                                    |
+| 9     | `SW_RESTORE`                         | Activates and displays the window. If the window is minimized, maximized, or arranged, the system restores it to its original size and position. An application should specify this flag when restoring a minimized window.           |
+| 10    | `SW_SHOWDEFAULT`                     | Sets the show state based on the `SW_` value specified in the `STARTUPINFO` structure passed to the `CreateProcess` function by the program that started the application.                                                             |
+| 11    | `SW_FORCEMINIMIZE`                   | Minimizes a window, even if the thread that owns the window is not responding. This flag should only be used when minimizing windows from a different thread.                                                                         |
+
+_Taken from [Microsoft documentation for `ShowWindow()` in the Windows API](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow#parameters)_
+
+## Error Codes
 
 | Value | Meaning                                                                                                                             |
 |:-----:|-------------------------------------------------------------------------------------------------------------------------------------|

--- a/RUNEXIT.DPR
+++ b/RUNEXIT.DPR
@@ -7,19 +7,43 @@ uses
 
 var
   h: Word;
+  reParam, reValue: String;
   pathName: String;
   fileName: String;
   params: String;
   errorMsg: String;
-  i, num: Integer;
+  i, num, pathIdx, nCmdShow: Integer;
 
 begin
+  { Set defaults }
+  nCmdShow := SW_SHOWNORMAL;
+
+  { Look for slash-options before the path param and handle them }
+  pathIdx := 1;
+  while ((pathIdx < paramCount) and (ParamStr(pathIdx)[1] = '/')) do
+  begin
+    { Split slash opts at equal sign }
+    i := Pos ('=', ParamStr(pathIdx));
+    if (i = 0) then i := Length(ParamStr(pathIdx)) + 1;
+    reParam := UpperCase(Copy(ParamStr(pathIdx), 2, i - 2));
+    reValue := Copy(ParamStr(pathIdx), i + 1, Length(ParamStr(pathIdx)) - i);
+
+    { Test each option type and extract its value - only one for now }
+    if (reParam = 'SHOW') then
+    begin
+      num := StrToIntDef(reValue, -1);
+      if ((num >= 0) and (num <= 11)) then nCmdShow := num;
+    end;
+
+    Inc(pathIdx);
+  end;
+
   { Split first parameter into path and filename }
-  i := Pos ('\', ParamStr (1));
+  i := Pos ('\', ParamStr (PathIdx));
   if (i > 0) then
   begin
     { Make it a path, find last occurrence of directory separator }
-    pathName := ParamStr (1);
+    pathName := ParamStr (PathIdx);
     i := (StrRScan (@pathName [1], '\') - @pathName [1]) + 1;
     fileName := Copy (pathName, i + 1, Length (pathName) - i);
     { Remove the trailing directory separator from path }
@@ -27,14 +51,15 @@ begin
     if pathName [i - 1] <> ':' then begin i := i - 1 end;
     pathName := Copy (pathName, 1, i);
   end else begin
-    fileName := ParamStr (1);
+    fileName := ParamStr (PathIdx);
   end;
 
   { Concatenate any remaining parameters }
+  Inc(pathIdx);
   num := ParamCount;
-  for i := 2 to num do
+  for i := pathIdx to num do
   begin
-    if (i > 2) then params := params + ' ';
+    if (i > pathIdx) then params := params + ' ';
     params := params + ParamStr (i);
   end;
 
@@ -44,7 +69,7 @@ begin
   params := params + #0;
 
   { Execute the command }
-  h := ShellExecute (0, nil, @fileName [1], @params [1], @pathName [1], SW_SHOWNORMAL);
+  h := ShellExecute (0, nil, @fileName [1], @params [1], @pathName [1], nCmdShow);
   if (h <= 32) then
   begin
     { A return value less than or equal to 32 specifies an error }


### PR DESCRIPTION
The previous version had hardcoded `SW_SHOWNORMAL` for the `nCmdShow` parameter to `ShellExecute()`, which caused the target application to always launch with its "default" window size.

Inspired by this [3-year-old Reddit post](https://www.reddit.com/r/RetroArch/comments/vxai89/dosboxwindows_3x_autolaunch_applicationgame_with/), I've added the ability to change `nCmdShow` by adding new param-parsing logic to `RunExit.exe`.  New parameters begin with a forward-slash and go between the `RunExit.exe` call and the target application path.

There is only one supported option (for now?), `/show=N`, where N is the number value corresponding to the nCmdShow to pass to ShellExecute.  A table of valid parameters is added to the `README`, as well as a link to Microsoft's documentation page for the `ShowWindow` function.  For example, `/show=2` starts the app minimized, while `/show=3` starts it maximized.