### PR TITLE
Option to delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ If ShellExecute fails to run the application, then a message box is displayed al
 * **Application startup behavior can be changed**  
 The default application startup `SW_SHOWNORMAL` can be overridden to a different value by passing a `/show=[number]` parameter to `RUNEXIT.EXE`, before the application path. This allows starting the application minimized, maximized, or in the "background" (not activated). A list of valid values are [here](#valid-ncmdshow-values).
 
+* **Optional delay before launching the application**  
+A delay (in seconds) can be specified before launching the application by passing a `/delay=[seconds]` parameter to `RUNEXIT.EXE`, before the application path. This is useful if you need to ensure Windows and its drivers are fully initialized before starting the application.  
+Example: `/delay=5` will wait 5 seconds before launching the application.
+
 # Usage
 
 Download `RUNEXIT.EXE` from the releases page and copy it to your system; these examples will assume that you save it to `C:\RUNEXIT\RUNEXIT.EXE` and that `win` is in your `PATH`.
@@ -56,6 +60,11 @@ Run application `C:\WEP\JEZZBALL.EXE` in a maximized window.
 `win C:\runexit\runexit.exe /show=3 c:\wep\jezzball.exe`
 
 ## Example 4
+Run application `C:\CASTLE\CASTLE.EXE` with a 5 second delay before launch.
+
+`win C:\runexit\runexit.exe /delay=5 c:\castle\castle.exe`
+
+## Example 5
 DOSBox AUTOEXEC to run application `C:\MPS\GPM\GPM.EXE` with no additional parameters.  
 On running DOSBox this would load Windows and run the application. Once the application is closed Windows will then exit, and DOSBox will close.
 

--- a/RUNEXIT.DPR
+++ b/RUNEXIT.DPR
@@ -13,10 +13,12 @@ var
   params: String;
   errorMsg: String;
   i, num, pathIdx, nCmdShow: Integer;
+  delaySeconds: Integer;
 
 begin
   { Set defaults }
   nCmdShow := SW_SHOWNORMAL;
+  delaySeconds := 0;
 
   { Look for slash-options before the path param and handle them }
   pathIdx := 1;
@@ -28,14 +30,28 @@ begin
     reParam := UpperCase(Copy(ParamStr(pathIdx), 2, i - 2));
     reValue := Copy(ParamStr(pathIdx), i + 1, Length(ParamStr(pathIdx)) - i);
 
-    { Test each option type and extract its value - only one for now }
+    { Test each option type and extract its value }
     if (reParam = 'SHOW') then
     begin
       num := StrToIntDef(reValue, -1);
       if ((num >= 0) and (num <= 11)) then nCmdShow := num;
+    end
+    else if (reParam = 'DELAY') then
+    begin
+      delaySeconds := StrToIntDef(reValue, 0);
     end;
 
     Inc(pathIdx);
+  end;
+
+  { Add delay if requested }
+  if delaySeconds > 0 then
+  begin
+    { Calculate the end time }
+    h := GetTickCount + (delaySeconds * 1000);
+    repeat
+      Application.ProcessMessages;
+    until GetTickCount >= h;
   end;
 
   { Split first parameter into path and filename }


### PR DESCRIPTION
I have a number of old Windows 3.1 games that if they are invoked immediately, like `WIN RUNEXIT C:\CASTLE\CASTLE.EXE CASTLE.BAP` or making a new program item in the startup directory with a command like `RUNEXIT C:\CASTLE\CASTLE.EXE CASTLE.BAP`, it results in either warnings about the audio device being busy or the audio of the game simply not working because it launched before Windows had a chance to initialize the audio device. Thus this PR to add an option to delay so that problematic games can be launched after Windows has had a chance to initialize the audio device.