### PR TITLE
Make it so the working directory can be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ This [tag](https://github.com/andshrew/RunExit/releases/tag/v1.1) contains [the 
 When parsing the application path to determine what the working directory should be set to, the original version would include the trailing `\` within the path and pass that through to ShellExecute.  
 eg. `C:\MPS\GPM\GPM.EXE` would set the working directory as `C:\MPS\GPM\`  
 This version sets the working directory without the trailing `\`:  
-`C:\MPS\GPM\GPM.EXE` now sets the working directory as `C:\MPS\GPM`  
+`C:\MPS\GPM\GPM.EXE` now sets the working directory as `C:\MPS\GPM`
+You can override the path of the working directory if the application needs to run in a different directory than the executable by passing a `/pwd=[path]` parameter to `RUNEXIT.EXE`, before the application path.
 
 * **Exit Windows will keep retrying for ~10 seconds**  
 Depending on the application being launched, sometimes the exit from Windows after the application had finished would intermittently (but consistently) fail.  
@@ -65,6 +66,11 @@ Run application `C:\CASTLE\CASTLE.EXE` with a 5 second delay before launch.
 `win C:\runexit\runexit.exe /delay=5 c:\castle\castle.exe`
 
 ## Example 5
+Run application `D:\WIN31\RBJR.EXE` with the working directory as `D:\RESOURCE`.
+
+`win C:\runexit\runexit.exe /pwd=D:\resource D:\win31\rbjr.EXE`
+
+## Example 6
 DOSBox AUTOEXEC to run application `C:\MPS\GPM\GPM.EXE` with no additional parameters.  
 On running DOSBox this would load Windows and run the application. Once the application is closed Windows will then exit, and DOSBox will close.
 

--- a/RUNEXIT.DPR
+++ b/RUNEXIT.DPR
@@ -41,6 +41,14 @@ begin
     begin
       num := StrToIntDef(reValue, 0);
       if ((num >= 0) and (num <= 30)) then delaySeconds := num;
+    end
+    else if (reParam = 'PWD') then
+    begin
+      pathName := reValue;
+      { Ensure path doesn't end with a backslash }
+      { Unless we're at the root ie. C:\ }
+      if (Length(pathName) > 3) and (pathName[Length(pathName)] = '\') then
+        Delete(pathName, Length(pathName), 1);
     end;
 
     Inc(pathIdx);
@@ -57,11 +65,11 @@ begin
   end;
 
   { Split first parameter into path and filename }
-  i := Pos ('\', ParamStr (PathIdx));
-  if (i > 0) then
+  i := Pos ('\', ParamStr (pathIdx));
+  if (i > 0) and (pathName = '') then
   begin
     { Make it a path, find last occurrence of directory separator }
-    pathName := ParamStr (PathIdx);
+    pathName := ParamStr (pathIdx);
     i := (StrRScan (@pathName [1], '\') - @pathName [1]) + 1;
     fileName := Copy (pathName, i + 1, Length (pathName) - i);
     { Remove the trailing directory separator from path }
@@ -69,7 +77,7 @@ begin
     if pathName [i - 1] <> ':' then begin i := i - 1 end;
     pathName := Copy (pathName, 1, i);
   end else begin
-    fileName := ParamStr (PathIdx);
+    fileName := ParamStr (pathIdx);
   end;
 
   { Concatenate any remaining parameters }


### PR DESCRIPTION
Got another one. Apparently, I've got a game that needs to run in a different directory than the executable is stored in otherwise, it can't find files it relies on. So needed a way to override the working directory.

I also noticed that one of the variables wasn't referenced with consistent casing, so I made it consistent to avoid confusion.